### PR TITLE
feat: allow manual WebSocket connection

### DIFF
--- a/frontend/src/hooks/useWebSocket.ts
+++ b/frontend/src/hooks/useWebSocket.ts
@@ -14,6 +14,7 @@ interface UseWebSocketOptions {
 
 export function useWebSocket(options: UseWebSocketOptions = {}) {
   const {
+    autoConnect = true,
     reconnectOnError = true,
     onConnect,
     onDisconnect,
@@ -112,10 +113,17 @@ export function useWebSocket(options: UseWebSocketOptions = {}) {
     wsService.reconnect();
   }, []);
 
+  // Manual connect
+  const connect = useCallback(() => {
+    wsService.initialize();
+  }, []);
+
   // Setup event listeners on mount
   useEffect(() => {
-    // Initialize WebSocket connection
-    wsService.initialize();
+    // Initialize WebSocket connection if enabled
+    if (autoConnect) {
+      wsService.initialize();
+    }
 
     // Setup error handling
     const unsubscribeError = wsService.onError(handleError);
@@ -138,7 +146,7 @@ export function useWebSocket(options: UseWebSocketOptions = {}) {
         clearTimeout(reconnectTimeoutRef.current);
       }
     };
-  }, [handleConnectionChange, handleError]);
+  }, [autoConnect, handleConnectionChange, handleError]);
 
   // Setup global event listeners for activity tracking
   useEffect(() => {
@@ -233,6 +241,7 @@ export function useWebSocket(options: UseWebSocketOptions = {}) {
     // Connection management
     ping,
     reconnect,
+    connect,
   };
 }
 


### PR DESCRIPTION
## Summary
- add `autoConnect` option to `useWebSocket` hook with default `true`
- only auto-initialize websocket when `autoConnect` is enabled
- expose `connect()` for manual websocket initialization

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: 248 problems)

------
https://chatgpt.com/codex/tasks/task_e_6899f5cd69388321ae4ed80c1cf09e5d