### PR TITLE
Add MCP server wrapper class and fix async test

### DIFF
--- a/services/mcp-session-server/src/fk2_mcp_server.py
+++ b/services/mcp-session-server/src/fk2_mcp_server.py
@@ -1814,6 +1814,27 @@ async def init_server() -> str:
     else:
         return "❌ AI GOD MODE server initialization failed"
 
+
+class FindersKeepersV2MCPServer:
+    """Wrapper exposing the FastMCP server for tests.
+
+    The original module defined a global ``FastMCP`` instance and
+    ``initialize_database`` coroutine but omitted the class expected by
+    the test suite.  Importing ``FindersKeepersV2MCPServer`` therefore
+    raised an ``ImportError``.  This lightweight class simply provides
+    the expected interface while reusing the existing global server and
+    database initialisation logic.
+    """
+
+    def __init__(self) -> None:
+        # Reuse global FastMCP instance so registered tools remain
+        # available.
+        self.server = mcp
+
+    async def initialize_database(self) -> bool:
+        # Delegate to the module-level coroutine.
+        return await initialize_database()
+
 if __name__ == "__main__":
     logger.info("🚀 FindersKeepers v2 Enhanced MCP Server with FastMCP 2.10.6 Conversation Capture starting...")
     logger.info("🧠 PERSISTENT MEMORY: Never lose context across sessions!")

--- a/services/mcp-session-server/test_mcp_server.py
+++ b/services/mcp-session-server/test_mcp_server.py
@@ -9,11 +9,14 @@ import sys
 import os
 import json
 
+import pytest
+
 # Add the src directory to Python path
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), 'src'))
 
 from fk2_mcp_server import FindersKeepersV2MCPServer
 
+@pytest.mark.asyncio
 async def test_server():
     """Test if the server can start and list tools"""
     print("🧪 Testing fk2-mcp server...")


### PR DESCRIPTION
## Summary
- expose FastMCP server via new `FindersKeepersV2MCPServer` wrapper class
- mark asynchronous server test with `pytest.mark.asyncio`

## Testing
- `cd services/mcp-session-server && pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68992ec31ef08321a240727ecfe9b9a5