### PR TITLE
chore(gitignore): ignore n8n/custom-nodes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,6 @@ config/secrets/
 *_temp
 *.backup
 *_backup
+
+# n8n local build artifacts (container-created; may be root-owned)
+n8n/custom-nodes/


### PR DESCRIPTION
Ignore n8n/custom-nodes because containers may create it as root, which breaks checkouts. No code changes.\n\n- Adds n8n/custom-nodes/ to .gitignore\n- Prevents VS Code/Git permission denied on branch switches\n\nAuto-merge enabled once checks pass.