### PR TITLE
docs: document shared Docker network setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,14 +27,21 @@ git clone https://github.com/bitcainnet/finderskeepers-v2.git
 cd finderskeepers-v2
 ```
 
-2. Start services:
+2. Create shared Docker network:
+```bash
+./ensure-network.sh
+# or manually:
+docker network create shared-network
+```
+
+3. Start services:
 ```bash
 docker compose up -d
 ```
 
-3. Wait for initialization (~5 minutes for model downloads)
+4. Wait for initialization (~5 minutes for model downloads)
 
-4. Verify health:
+5. Verify health:
 ```bash
 ./scripts/health.sh
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -454,7 +454,6 @@ services:
 networks:
   shared-network:
     name: shared-network
-    external: true
 
 volumes:
   # Named volumes for data persistence

--- a/scripts/start-all.sh
+++ b/scripts/start-all.sh
@@ -43,6 +43,10 @@ mkdir -p logs
 chmod -R 755 data/
 chmod -R 755 logs/
 
+# Ensure shared network exists
+echo "🌐 Ensuring shared Docker network exists..."
+./ensure-network.sh
+
 # Pull latest images
 echo "📦 Pulling latest Docker images..."
 docker compose pull


### PR DESCRIPTION
## Summary
- document the need to create the `shared-network` before launching containers
- ensure `start-all.sh` creates the Docker network automatically
- let docker compose create the network by default

## Testing
- `pytest -q` *(fails: async def functions are not natively supported)*
- `docker-compose config`

------
https://chatgpt.com/codex/tasks/task_e_689db1ba12588321aa6329a6d4df8ca9