### PR TITLE
Use named volume for frontend node modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,17 @@ finderskeepers-v2/
 └── docker-compose.yml     # Service orchestration
 ```
 
+### Updating Frontend Dependencies
+
+The frontend's `node_modules` directory is stored in a named Docker volume to avoid
+conflicts with files on the host. If you change dependencies, remove this volume
+before rebuilding:
+
+```bash
+./scripts/prune-frontend-node-modules.sh
+docker compose build frontend
+```
+
 ### Key Technologies
 - **Backend**: FastAPI, PostgreSQL (pgvector), Neo4j, Qdrant
 - **AI/ML**: Ollama, Llama3 8B, mxbai-embed-large

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -414,7 +414,7 @@ services:
       - VITE_PROCESSING_STATS_ENABLED=true
     volumes:
       - ./fk2_frontend:/app
-      - /app/node_modules
+      - frontend_node_modules:/app/node_modules # run ./scripts/prune-frontend-node-modules.sh after dependency changes
       - /var/run/docker.sock:/var/run/docker.sock:ro
     deploy:
       resources:
@@ -465,6 +465,7 @@ volumes:
   redis_data:
   n8n_data:
   ollama_data:
+  frontend_node_modules:
 
 # ========================================
 # bitcain USAGE INSTRUCTIONS - UPDATED FOR ADMIN/MAINTENANCE INTERFACE

--- a/scripts/prune-frontend-node-modules.sh
+++ b/scripts/prune-frontend-node-modules.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# Removes the frontend node_modules volume to ensure a clean reinstall of dependencies.
+# Usage: ./scripts/prune-frontend-node-modules.sh [project-name]
+set -e
+PROJECT_NAME=${1:-finderskeepers-v2}
+VOLUME_NAME="${PROJECT_NAME}_frontend_node_modules"
+if docker volume inspect "$VOLUME_NAME" >/dev/null 2>&1; then
+  echo "Removing volume $VOLUME_NAME"
+  docker volume rm "$VOLUME_NAME"
+else
+  echo "Volume $VOLUME_NAME not found. Nothing to remove."
+fi
+


### PR DESCRIPTION
## Summary
- Replace anonymous `/app/node_modules` mount with named `frontend_node_modules` volume in `docker-compose.yml`
- Document how to clear the volume when frontend dependencies change
- Add helper script `prune-frontend-node-modules.sh`

## Testing
- `./scripts/prune-frontend-node-modules.sh`
- `docker-compose build frontend` *(fails: Error while fetching server API version: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_689db18bb2348321a1b5792309ae025e