### PR TITLE
Use service name for frontend FastAPI endpoints

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -399,8 +399,8 @@ services:
       - "3000:3000"
     environment:
       - NODE_ENV=development
-      - VITE_API_URL=http://localhost:8000
-      - VITE_WS_URL=ws://localhost:8000
+      - VITE_API_URL=http://fastapi:8000
+      - VITE_WS_URL=ws://fastapi:8000
       - VITE_NEO4J_URI=bolt://localhost:7687
       - VITE_NEO4J_USER=neo4j
       - VITE_NEO4J_PASSWORD=${NEO4J_PASSWORD:-changeme_neo4j_password}


### PR DESCRIPTION
## Summary
- Point VITE_API_URL and VITE_WS_URL to the fastapi service so the frontend uses Docker networking

## Testing
- `docker compose build frontend` *(fails: command not found)*
- `docker compose up -d frontend` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689db1754d8083218527e73a8eb7b06b